### PR TITLE
Reducir peticiones

### DIFF
--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -72,6 +72,10 @@ function Profile({ token, setToken }) {
         setPicture(pictureURL);
       }
     });
+  }, []);
+
+  useEffect(() => {
+    if (username === "") return;
 
     getUserStats({ username }).then((response) => {
       if ("error" in response) {
@@ -83,7 +87,7 @@ function Profile({ token, setToken }) {
         setTimePlayed(response.playtime_mins);
       }
     });
-  });
+  }, [username]);
 
   const handleClick = async (e) => {
     e.preventDefault();


### PR DESCRIPTION
Me he dado cuenta de que el uso de `useEffect` no es el correcto.

`useEffect` sin parámetros se ejecuta cada vez que se redibuja la aplicación (con cualquier cambio de estado). Esto suponía que cada vez se hiciera una petición al servidor. Ref: https://daveceddia.com/useeffect-hook-examples/#only-run-once-on-mount

Por otra parte, las estadísticas del usuario solo las queremos obtener una vez ha cambiado la variable del nombre del usuario (para evitar una petición vacía). Para eso se puede poner la variable como dependencia del `useEffect` (así solo se ejecutará cuando esta cambie). Ref: https://daveceddia.com/useeffect-hook-examples/#prevent-useeffect-from-running-every-render