### PR TITLE
Fix css en despliegue

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -10,9 +10,6 @@ import SignUp from "./SignUp";
 import Shop from "./Shop";
 import Help from "./Help";
 
-import "../style.css";
-import "bootstrap/dist/css/bootstrap.min.css";
-
 function App() {
   const [token, setToken] = useState(null);
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,11 @@ import ReactDOM from "react-dom";
 import { PopupboxContainer } from "react-popupbox";
 import { HashRouter as Router } from "react-router-dom";
 
-import "./style.css";
-import "react-popupbox/dist/react-popupbox.css";
+(async function() {
+  await import('./style.css')
+  await import('bootstrap/dist/css/bootstrap.min.css')
+  await import('react-popupbox/dist/react-popupbox.css')
+})()
 
 import reportWebVitals from "./reportWebVitals";
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,11 +4,11 @@ import ReactDOM from "react-dom";
 import { PopupboxContainer } from "react-popupbox";
 import { HashRouter as Router } from "react-router-dom";
 
-(async function() {
-  await import('./style.css')
-  await import('bootstrap/dist/css/bootstrap.min.css')
-  await import('react-popupbox/dist/react-popupbox.css')
-})()
+(async function () {
+  await import("./style.css");
+  await import("bootstrap/dist/css/bootstrap.min.css");
+  await import("react-popupbox/dist/react-popupbox.css");
+})();
 
 import reportWebVitals from "./reportWebVitals";
 


### PR DESCRIPTION
Se debe a que React hace lazy load de los css, para solo descargarlos cuando los usa. Esto puede hacer que se descarguen en otro orden. He forzado el orden cargándolos al inicio en el orden especificado. No se si es buena idea, pero es la única que he encontrado.

Closes #85 